### PR TITLE
removed trailing comma before splitting

### DIFF
--- a/src/gfa.rs
+++ b/src/gfa.rs
@@ -283,6 +283,7 @@ impl<T: OptFields> Path<usize, T> {
         &'a self,
     ) -> impl Iterator<Item = (usize, Orientation)> + 'a {
         self.segment_names
+            .trim_end_with(|c| c == ',')
             .split_str(b",")
             .filter_map(Self::parse_segment_id)
     }


### PR DESCRIPTION
Hi Chris,

in some GFA files I have paths with trailing commas, which lead to panic if given as input to tools that use this crate, as `rs-gfa-utils`. This should fix the problem. Could you take a look at it, please?