### PR TITLE
Add `walks` parser for GFA-v1.1 

### DIFF
--- a/test/gfas/walks.gfa
+++ b/test/gfas/walks.gfa
@@ -1,0 +1,8 @@
+H	VN:Z:1.1
+S	s11	ACCTT
+S	s12	TC
+S	s13	GATT
+L	s11	+	s12	-	0M
+L	s12	-	s13	+	0M
+L	s11	+	s13	+	0M
+W	NA12878	1	chr1	0	11	>s11<s12>s13


### PR DESCRIPTION
Hi @chfi !

Thanks for this awesome crate!

This PR adds support for parsing Walks (W) lines as defined in the [GFA v1.1 specification](https://github.com/GFA-spec/GFA-spec/blob/master/GFA1.md#w-walk-line-since-v11).

Key Changes:
	1.	Parsing Logic: Implemented handling for Walks lines, including field extraction and validation.
	2.	Unit Tests: Added test cases to ensure correctness and compatibility with GFA v1.1.

This update ensures full compliance with the GFA v1.1 standard while maintaining backward compatibility with GFA v1.0.

Best regards,
Wenjie